### PR TITLE
Feature/Adds Marko live coding event for 8/13/2020 @7:00PM EDT

### DIFF
--- a/components/Event.vue
+++ b/components/Event.vue
@@ -1,6 +1,6 @@
 <template>
   <article class="pt-6">
-    <page-subtext>{{ datetime.toFormat("FF") }}</page-subtext>
+    <page-subtext>{{ datetime.toFormat("ff") }}</page-subtext>
     <page-header2>{{ title }}</page-header2>
     <paragraph>{{ summary }}</paragraph>
     <div class="flex flex-col md:flex-row py-6">

--- a/content/events/2020-08-13.md
+++ b/content/events/2020-08-13.md
@@ -2,6 +2,7 @@
 title: Live Coding With Marko - APIs & Angular State Management
 datetime: 2020-08-13 19:00
 summary: Join us for a special Front End Columbus! Marko Skugor will be live coding a project to demonstrate the basics of Angular state management, and integrating an API into a front end application.
+rsvp: https://www.meetup.com/Front-End-Columbus/events/272388282/
 ---
 <page-paragraph>
 Join us for a special Front End Columbus! Marko Skugor will be live coding a project to demonstrate the basics of Angular state management, and integrating an API into a front end application.

--- a/content/events/2020-08-13.md
+++ b/content/events/2020-08-13.md
@@ -1,0 +1,16 @@
+---
+title: Live Coding With Marko - APIs & Angular State Management
+datetime: 2020-08-13 19:00
+summary: Join us for a special Front End Columbus! Marko Skugor will be live coding a project to demonstrate the basics of Angular state management, and integrating an API into a front end application.
+---
+<page-paragraph>
+Join us for a special Front End Columbus! Marko Skugor will be live coding a project to demonstrate the basics of Angular state management, and integrating an API into a front end application.
+</page-paragraph>
+
+--- 
+<page-header2>
+📅 Schedule:
+</page-header2>
+
+➡️ 7:00 PM - 9:00 PM
+Live coding


### PR DESCRIPTION
Not sure if we want to add link to where stream will be with button to open from the event page/tab.
Maybe add a ribbon to the top of page to let visitors know Marko's session is live with cta/button to join google meet stream.